### PR TITLE
Align facilitator status badges with name and streamline next-step guidance

### DIFF
--- a/templates/unitcoordinator_dashboard.html
+++ b/templates/unitcoordinator_dashboard.html
@@ -1018,9 +1018,8 @@
                     <div class="flex items-start justify-between gap-6">
                       <!-- Left: identity + contact -->
                       <div>
-                        <div class="flex items-center gap-3">
-                          <h4 class="font-semibold text-gray-900">{{ f.name }}</h4>
-
+                        <div class="flex flex-wrap items-baseline gap-2">
+                          <h4 class="font-semibold text-gray-900 text-lg mr-2">{{ f.name }}</h4>
                           {% if f.is_ready %}
                             <span class="status-badge status-badge--green">
                               <span class="material-icons">check_circle</span> Ready
@@ -1032,7 +1031,6 @@
                             <span class="status-badge status-badge--amber">
                               <span class="material-icons">priority_high</span> Needs Skills
                             </span>
-
                           {% elif f.has_profile and not f.has_availability %}
                             <span class="status-badge status-badge--amber">
                               <span class="material-icons">hourglass_bottom</span> Pending
@@ -1040,7 +1038,6 @@
                             <span class="status-badge status-badge--amber">
                               <span class="material-icons">priority_high</span> Needs Availability
                             </span>
-
                           {% else %}
                             <span class="status-badge status-badge--gray">
                               <span class="material-icons">pause_circle</span> Inactive
@@ -1049,7 +1046,6 @@
                               <span class="material-icons">warning</span> Setup Required
                             </span>
                           {% endif %}
-
                         </div>
 
                         <div class="mt-2 space-y-1 text-sm text-gray-800">


### PR DESCRIPTION
<img width="2140" height="668" alt="image" src="https://github.com/user-attachments/assets/6c99ee5a-6c9c-4255-9445-7a9abd37dde1" />
<img width="1063" height="342" alt="Screenshot 2025-11-14 at 11 01 07 pm" src="https://github.com/user-attachments/assets/1deb477f-a954-40e7-995b-050a4238fb5f" />

tldr;
keep “Pending”/“Needs Availability” chips inline with the facilitator name for better readability
switch status row to a single “Next steps” checklist that only shows what’s outstanding
ensure badges use baseline alignment so text and pills share the same visual baseline


